### PR TITLE
Fix the service in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ mvn -Predhat,openshift fabric8:deploy -DskipTests
 Then, you can test the service deployed in OpenShift and get a response message 
 
 ```
-http $(minishift service rest --url=true)/greeting
+http $(minishift service springboot-rest --url=true)/greeting
 ```
 
 To test the project against OpenShift using Arquillian, simply run this command


### PR DESCRIPTION
+++
[jfclere@jfcpc MINI]$ oc get services
NAME              CLUSTER-IP      EXTERNAL-IP                     PORT(S)                 AGE
docker-registry   172.30.206.11   <nodes>                         5000/TCP                27m
kubernetes        172.30.0.1      <none>                          443/TCP,53/UDP,53/TCP   27m
springboot-rest   172.30.52.16    172.46.254.226,172.46.254.226   80/TCP                  11m
+++
So the name is springboot-rest and not rest.